### PR TITLE
Add toe distance metrics and image validation

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import cv2
 from pydantic import BaseModel, ValidationError, validator
 from mobile_sam_podiatry import MobileSAMPodiatryPipeline, quick_measure, batch_process_folder, validate_setup
 
@@ -19,6 +20,12 @@ class FaceImages(BaseModel):
             raise ValueError('fichier introuvable')
         if not v.lower().endswith(('.jpg', '.jpeg', '.png')):
             raise ValueError('format image non supporté')
+        img = cv2.imread(v)
+        if img is None:
+            raise ValueError('image illisible')
+        h, w = img.shape[:2]
+        if h < 100 or w < 100:
+            raise ValueError('image trop petite (min 100x100)')
         return v
 
 

--- a/mobile_sam_podiatry.py
+++ b/mobile_sam_podiatry.py
@@ -487,7 +487,7 @@ class MobileSAMPodiatryPipeline:
         instep_info = estimateInstepHeightRobust(foot_contour, ratio_mm, ratio_mm)
         arch_info = analyzeArchSupportRobust(foot_contour, ratio_mm, ratio_mm)
         left_len, right_len = self._calculate_side_lengths(foot_contour, ratio_px_mm)
-        toe_info = self._analyze_toes(foot_contour, heel_point, toe_point)
+        toe_info = self._analyze_toes(foot_contour, heel_point, toe_point, ratio_px_mm)
 
         measurements.update({
             'heel_width_cm': heel_info.get('heel_width_cm'),
@@ -624,8 +624,8 @@ class MobileSAMPodiatryPipeline:
 
         return round(arc_len(left), 2), round(arc_len(right), 2)
 
-    def _analyze_toes(self, contour, heel_point, toe_point):
-        """Analyse l'orientation des orteils"""
+    def _analyze_toes(self, contour, heel_point, toe_point, ratio_px_mm=1.0):
+        """Analyse l'orientation des orteils et distances orteils/talon"""
         pts = contour[:, 0, :]
         y_min = pts[:, 1].min()
         y_max = pts[:, 1].max()
@@ -656,9 +656,14 @@ class MobileSAMPodiatryPipeline:
         hallux = angle(axis_vec, big_vec)
         opening = angle(big_vec, little_vec)
 
+        dist_big = distance.euclidean(big_toe, heel_point) / ratio_px_mm / 10
+        dist_little = distance.euclidean(little_toe, heel_point) / ratio_px_mm / 10
+
         return {
             'hallux_valgus_angle_deg': round(hallux, 1),
             'toe_opening_angle_deg': round(opening, 1),
+            'bigtoe_to_heel_cm': round(dist_big, 2),
+            'littletoe_to_heel_cm': round(dist_little, 2),
         }
     
     def _clean_mask(self, mask):

--- a/tests/test_toes.py
+++ b/tests/test_toes.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+import types, sys
+
+sys.modules['torch'] = types.ModuleType('torch')
+sys.modules['torch'].cuda = types.SimpleNamespace(is_available=lambda: False)
+
+scipy_mod = types.ModuleType('scipy')
+spatial_mod = types.ModuleType('spatial')
+def euclid(a,b):
+    a=np.array(a);b=np.array(b)
+    return float(np.sqrt(((a-b)**2).sum()))
+distance_mod = types.SimpleNamespace(euclidean=euclid)
+spatial_mod.distance = distance_mod
+scipy_mod.spatial = spatial_mod
+sys.modules['scipy'] = scipy_mod
+sys.modules['scipy.spatial'] = spatial_mod
+sys.modules['scipy.spatial.distance'] = distance_mod
+sys.modules['sklearn'] = types.ModuleType('sklearn')
+sys.modules['sklearn.cluster'] = types.ModuleType('cluster')
+sys.modules['sklearn.cluster'].KMeans = object
+sys.modules['imutils'] = types.ModuleType('imutils')
+sys.modules['skimage'] = types.ModuleType('skimage')
+sys.modules['skimage.io'] = types.ModuleType('io')
+sys.modules['skimage.io'].imread = lambda x: None
+sys.modules['matplotlib'] = types.ModuleType('matplotlib')
+sys.modules['matplotlib.pyplot'] = types.ModuleType('pyplot')
+
+from mobile_sam_podiatry import MobileSAMPodiatryPipeline
+
+
+def test_toe_distance():
+    pipe = MobileSAMPodiatryPipeline.__new__(MobileSAMPodiatryPipeline)
+    contour = np.array([[[0,0]], [[5,20]], [[10,0]]], dtype=np.int32)
+    heel = np.array([5,20])
+    toe = np.array([5,0])
+    res = pipe._analyze_toes(contour, heel, toe, ratio_px_mm=1.0)
+    assert res['bigtoe_to_heel_cm'] == pytest.approx(2.06, rel=1e-2)
+    assert res['littletoe_to_heel_cm'] == pytest.approx(2.06, rel=1e-2)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,35 @@
+import numpy as np
+import cv2
+import types, sys
+
+sys.modules['torch'] = types.ModuleType('torch')
+sys.modules['torch'].cuda = types.SimpleNamespace(is_available=lambda: False)
+
+scipy_mod = types.ModuleType('scipy')
+spatial_mod = types.ModuleType('spatial')
+distance_mod = types.SimpleNamespace(euclidean=lambda a,b: 0.0)
+spatial_mod.distance = distance_mod
+scipy_mod.spatial = spatial_mod
+sys.modules['scipy'] = scipy_mod
+sys.modules['scipy.spatial'] = spatial_mod
+sys.modules['scipy.spatial.distance'] = distance_mod
+sys.modules['sklearn'] = types.ModuleType('sklearn')
+sys.modules['sklearn.cluster'] = types.ModuleType('cluster')
+sys.modules['sklearn.cluster'].KMeans = object
+sys.modules['imutils'] = types.ModuleType('imutils')
+sys.modules['skimage'] = types.ModuleType('skimage')
+sys.modules['skimage.io'] = types.ModuleType('io')
+sys.modules['skimage.io'].imread = lambda x: None
+sys.modules['matplotlib'] = types.ModuleType('matplotlib')
+sys.modules['matplotlib.pyplot'] = types.ModuleType('pyplot')
+
+from main import FaceImages
+
+
+def test_faceimages_validation(tmp_path):
+    img = np.zeros((120, 120, 3), dtype=np.uint8)
+    f = tmp_path / "img.jpg"
+    cv2.imwrite(str(f), img)
+    data = {k: str(f) for k in ['top','left','right','front','back']}
+    obj = FaceImages(**data)
+    assert obj.top == str(f)


### PR DESCRIPTION
## Summary
- validate images with OpenCV
- compute distances from big and little toe to heel
- pass measurement ratio to toe analysis
- add basic unit tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c37770ccc8330b0c82ec553fc6a85