### PR TITLE
Add hybrid side/top view foot measurement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ python main.py
 # - Warning if measurement seems incorrect
 ```
 
+### Hybrid two-photo pipeline
+The updated pipeline can combine a top view of the foot with a side view. The top
+view is used to measure width and evaluate the plantar arch, while the side view
+provides the length, arch height and arch angle. Example usage:
+
+```python
+from mobile_sam_podiatry import MobileSAMPodiatryPipeline
+
+pipeline = MobileSAMPodiatryPipeline()
+result = pipeline.process_hybrid_views('top.jpg', 'side.jpg')
+print(result)
+```
+
 ## Working Aproach
 * convert raw image to HSV format
 * Remove noise using Gaussian Blur


### PR DESCRIPTION
## Summary
- add side view and top view measurement helpers in `MobileSAMPodiatryPipeline`
- expose new `process_hybrid_views` method
- document hybrid usage in README

## Testing
- `python -m py_compile mobile_sam_podiatry.py`

------
https://chatgpt.com/codex/tasks/task_e_688baa9a4fe88330b4b293d920d491c7